### PR TITLE
fix #6: add support for strings with dates only

### DIFF
--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -6,7 +6,7 @@ module Iso8601 exposing (fromTime, toTime)
 
 -}
 
-import Parser exposing ((|.), (|=), Parser, andThen, int, map, oneOf, succeed, symbol)
+import Parser exposing ((|.), (|=), Parser, andThen, int, map, oneOf, succeed, symbol, end)
 import Time exposing (Month(..), utc)
 
 
@@ -312,6 +312,7 @@ iso8601 =
                                 |= paddedInt 2
                             ]
                     , succeed (fromParts datePart 0 0 0 0 0)
+                        |. end
                     ]
             )
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -22,6 +22,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "1970-01-01T00:00:00Z"
                     |> Expect.equal (Ok (Time.millisToPosix 0))
+        , test "toTime \"1970-01-01\" gives me 0" <|
+            \_ ->
+                Iso8601.toTime "1970-01-01"
+                    |> Expect.equal (Ok (Time.millisToPosix 0))
         ]
 
 


### PR DESCRIPTION
https://github.com/rtfeldman/elm-iso8601-date-strings/issues/6

I was able to figure out fix by myself. Hopefully it is ok.