### PR TITLE
Support micro- and nano- precision

### DIFF
--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -54,24 +54,28 @@ paddedInt : Int -> Parser Int
 paddedInt quantity =
     Parser.chompWhile Char.isDigit
         |> Parser.getChompedString
-        |> Parser.andThen
-            (\str ->
-                if String.length str == quantity then
-                    -- StringtoInt works on zero-padded integers
-                    case String.toInt str of
-                        Just intVal ->
-                            Parser.succeed intVal
+        |> Parser.andThen (paddedStringToInt quantity)
 
-                        Nothing ->
-                            Parser.problem ("Invalid integer: \"" ++ str ++ "\"")
 
-                else
-                    Parser.problem
-                        ("Expected "
-                            ++ String.fromInt quantity
-                            ++ " digits, but got "
-                            ++ String.fromInt (String.length str)
-                        )
+{-| Extract a fixed-length integer from the string.
+-}
+paddedStringToInt : Int -> String -> Parser Int
+paddedStringToInt quantity str =
+    if String.length str == quantity then
+        -- StringtoInt works on zero-padded integers
+        case String.toInt str of
+            Just intVal ->
+                Parser.succeed intVal
+
+            Nothing ->
+                Parser.problem ("Invalid integer: \"" ++ str ++ "\"")
+
+    else
+        Parser.problem
+            ("Expected "
+                ++ String.fromInt quantity
+                ++ " digits, but got "
+                ++ String.fromInt (String.length str)
             )
 
 
@@ -317,7 +321,7 @@ iso8601 =
                         |= oneOf
                             [ succeed identity
                                 |. symbol "."
-                                |= paddedInt 3
+                                |= milliMicroNanoInMs
                             , succeed 0
                             ]
                         -- SSS
@@ -338,6 +342,25 @@ iso8601 =
                     , succeed (fromParts datePart 0 0 0 0 0)
                         |. end
                     ]
+            )
+
+
+{-| Parse milli-, micro-, or nanoseconds and convert to milliseconds
+-}
+milliMicroNanoInMs : Parser Int
+milliMicroNanoInMs =
+    Parser.chompWhile Char.isDigit
+        |> Parser.getChompedString
+        |> Parser.andThen
+            (\str ->
+                List.range 1 3
+                    |> List.map
+                        (\precision ->
+                            map
+                                (\s -> s // (1000 ^ (precision - 1)))
+                                (paddedStringToInt (3 * precision) str)
+                        )
+                    |> oneOf
             )
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -46,6 +46,14 @@ knownValues =
             \_ ->
                 Iso8601.toTime "1970-01-01"
                     |> Expect.equal (Ok (Time.millisToPosix 0))
+        , test "toTime supports microseconds precision" <|
+            \_ ->
+                Iso8601.toTime "2018-08-31T23:25:16.019345+02:00"
+                    |> Expect.equal (Ok (Time.millisToPosix 1535750716019))
+        , test "toTime supports nanoseconds precision" <|
+            \_ ->
+                Iso8601.toTime "2018-08-31T23:25:16.019345123+02:00"
+                    |> Expect.equal (Ok (Time.millisToPosix 1535750716019))
         ]
 
 


### PR DESCRIPTION
I'm porting https://github.com/prometheus/alertmanager UI to 0.19 and decided to use this nice library! However I noticed that the dates that I'm getting from the backend cannot be parsed. 

The actual data coming from Go is `2018-08-31T23:25:16.019345+02:00` that seems to conform with the ISO8601 standard. 

After googling around I found this article: https://nbsoftsolutions.com/blog/iso-8601-and-nanosecond-precision-across-languages

Even though we don't support such precisions, I believe that the parser should not fail in this situation.
