### PR TITLE
Support variable milliseconds precision

### DIFF
--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -54,6 +54,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2018-08-31T23:25:16.019345123+02:00"
                     |> Expect.equal (Ok (Time.millisToPosix 1535750716019))
+        , test "toTime doesn't support fractions more than 9 digits" <|
+            \_ ->
+                Iso8601.toTime "2018-08-31T23:25:16.0123456789+02:00"
+                    |> Expect.err
         ]
 
 


### PR DESCRIPTION
I'm really sorry for the other PR. It seems like the Go backend is fuzz testing the Elm frontend, and I got a value in which the fraction is not rounded to milli-, micro- or nanoseconds: `2018-09-01T20:46:47.23833Z`.

The solution I came up with is maybe less elegant. I extract fractions into a float and then convert it to integer milliseconds.