### PR TITLE
Add support for Facebook datetime type:

### DIFF
--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -30,6 +30,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2012-11-12T00:00:00+01:00"
                     |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
+        , test "toTime \"2012-11-12T00:00:00+0100\" gives me 1352674800000" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+0100"
+                    |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
         , test "-5:00 is an invalid UTC offset (should be -05:00)" <|
             \_ ->
                 Iso8601.toTime "2012-04-01T00:00:00-5:00"


### PR DESCRIPTION
@rtfeldman Is this something that you would accept to have as part as this lib?

```{
      "created_time": "2017-04-06T22:04:21+0000",
      "from": {
        "name": "Jay P Jeanne",
        "id": "126577551217199"
      },
      "id": "126577551217199_122842541590700",
      "message": "Hello",
      "permalink_url": "https://www.facebook.com/126577551217199/posts/122842541590700",
    }```