### PR TITLE
support no delimeters in date and time parts

### DIFF
--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -52,27 +52,24 @@ toTime str =
 -}
 paddedInt : Int -> Parser Int
 paddedInt quantity =
-    Parser.chompWhile Char.isDigit
-        |> Parser.getChompedString
-        |> Parser.andThen
-            (\str ->
-                if String.length str == quantity then
-                    -- StringtoInt works on zero-padded integers
-                    case String.toInt str of
-                        Just intVal ->
-                            Parser.succeed intVal
+    let
+        helper str =
+            if String.length str == quantity then
+                -- StringtoInt works on zero-padded integers
+                case String.toInt str of
+                    Just intVal ->
+                        Parser.succeed intVal
+                            |> Parser.map Parser.Done
 
-                        Nothing ->
-                            Parser.problem ("Invalid integer: \"" ++ str ++ "\"")
+                    Nothing ->
+                        Parser.problem ("Invalid integer: \"" ++ str ++ "\"")
 
-                else
-                    Parser.problem
-                        ("Expected "
-                            ++ String.fromInt quantity
-                            ++ " digits, but got "
-                            ++ String.fromInt (String.length str)
-                        )
-            )
+            else
+                Parser.chompIf Char.isDigit
+                    |> Parser.getChompedString
+                    |> Parser.map (\nextChar -> Parser.Loop <| String.append str nextChar)
+    in
+    Parser.loop "" helper
 
 
 msPerYear : Int
@@ -308,11 +305,19 @@ iso8601 =
                         |. symbol "T"
                         |= paddedInt 2
                         -- HH
-                        |. symbol ":"
-                        |= paddedInt 2
+                        |= oneOf
+                            [ succeed identity
+                                |. symbol ":"
+                                |= paddedInt 2
+                            , paddedInt 2
+                            ]
                         -- mm
-                        |. symbol ":"
-                        |= paddedInt 2
+                        |= oneOf
+                            [ succeed identity
+                                |. symbol ":"
+                                |= paddedInt 2
+                            , paddedInt 2
+                            ]
                         -- ss
                         |= oneOf
                             [ succeed identity
@@ -377,11 +382,19 @@ monthYearDayInMs =
     Parser.succeed (\year month day -> ( year, month, day ))
         |= paddedInt 4
         -- YYYY
-        |. symbol "-"
-        |= paddedInt 2
+        |= oneOf
+            [ succeed identity
+                |. symbol "-"
+                |= paddedInt 2
+            , paddedInt 2
+            ]
         -- MM
-        |. symbol "-"
-        |= paddedInt 2
+        |= oneOf
+            [ succeed identity
+                |. symbol "-"
+                |= paddedInt 2
+            , paddedInt 2
+            ]
         -- DD
         |> Parser.andThen yearMonthDay
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -58,6 +58,14 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2018-08-31T23:25:16.0123456789+02:00"
                     |> Expect.err
+        , test "toTime supports no delimeters" <|
+            \_ ->
+                Iso8601.toTime "20180831T232516Z"
+                    |> Expect.equal (Ok (Time.millisToPosix 1535757916000))
+        , test "toTime supports nanoseconds precision when there are no delimeters" <|
+            \_ ->
+                Iso8601.toTime "20180831T232516.019345123+02:00"
+                    |> Expect.equal (Ok (Time.millisToPosix 1535750716019))
         ]
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -66,6 +66,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "20180831T232516.019345123+02:00"
                     |> Expect.equal (Ok (Time.millisToPosix 1535750716019))
+        , test "toTime fails with no delimeters and not enough numbers" <|
+            \_ ->
+                Iso8601.toTime "2080831T232516Z"
+                    |> Expect.err
         ]
 
 


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/elm-iso8601-date-strings/issues/13

According to standard having no delimeters in both date and time parts is a valid option.