### PR TITLE
Support for no delimeters in offset

### DIFF
--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -327,6 +327,7 @@ iso8601 =
                             ]
                         -- SSS
                         |= utcOffsetInMinutes
+                        |. end
                     , succeed (fromParts datePart 0 0 0 0 0)
                         |. end
                     ]
@@ -336,14 +337,10 @@ iso8601 =
 utcOffsetInMinutes : Parser Int
 utcOffsetInMinutes =
     let
-        offsetInMinutes : Int -> Int -> Int
-        offsetInMinutes hours minutes =
-            (hours * 60) + minutes
-
-        utcOffsetMinutesFromParts : Int -> Int -> Int
-        utcOffsetMinutesFromParts multiplier calculatedOffset =
+        utcOffsetMinutesFromParts : Int -> Int -> Int -> Int
+        utcOffsetMinutesFromParts multiplier hours minutes =
             -- multiplier is either 1 or -1 (for negative UTC offsets)
-            multiplier * calculatedOffset
+            multiplier * (hours * 60) + minutes
     in
     Parser.succeed identity
         |= oneOf
@@ -357,17 +354,13 @@ utcOffsetInMinutes =
                     , map (\_ -> -1) (symbol "-")
                     ]
                 -- support 01, 0100 and 01:00
+                |= paddedInt 2
                 |= oneOf
-                    [ succeed offsetInMinutes
-                        |= paddedInt 2
-                        |= succeed 0
-                    , succeed offsetInMinutes
-                        |= paddedInt 2
-                        |= paddedInt 2
-                    , succeed offsetInMinutes
-                        |= paddedInt 2
+                    [ succeed identity
                         |. symbol ":"
                         |= paddedInt 2
+                    , paddedInt 2
+                    , succeed 0
                     ]
             ]
 

--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -52,27 +52,24 @@ toTime str =
 -}
 paddedInt : Int -> Parser Int
 paddedInt quantity =
-    Parser.chompWhile Char.isDigit
-        |> Parser.getChompedString
-        |> Parser.andThen
-            (\str ->
-                if String.length str == quantity then
-                    -- StringtoInt works on zero-padded integers
-                    case String.toInt str of
-                        Just intVal ->
-                            Parser.succeed intVal
+    let
+        helper str =
+            if String.length str == quantity then
+                -- StringtoInt works on zero-padded integers
+                case String.toInt str of
+                    Just intVal ->
+                        Parser.succeed intVal
+                            |> Parser.map Parser.Done
 
-                        Nothing ->
-                            Parser.problem ("Invalid integer: \"" ++ str ++ "\"")
+                    Nothing ->
+                        Parser.problem ("Invalid integer: \"" ++ str ++ "\"")
 
-                else
-                    Parser.problem
-                        ("Expected "
-                            ++ String.fromInt quantity
-                            ++ " digits, but got "
-                            ++ String.fromInt (String.length str)
-                        )
-            )
+            else
+                Parser.chompIf Char.isDigit
+                    |> Parser.getChompedString
+                    |> Parser.map (\nextChar -> Parser.Loop <| String.append str nextChar)
+    in
+    Parser.loop "" helper
 
 
 msPerYear : Int
@@ -308,11 +305,19 @@ iso8601 =
                         |. symbol "T"
                         |= paddedInt 2
                         -- HH
-                        |. symbol ":"
-                        |= paddedInt 2
+                        |= oneOf
+                            [ succeed identity
+                                |. symbol ":"
+                                |= paddedInt 2
+                            , paddedInt 2
+                            ]
                         -- mm
-                        |. symbol ":"
-                        |= paddedInt 2
+                        |= oneOf
+                            [ succeed identity
+                                |. symbol ":"
+                                |= paddedInt 2
+                            , paddedInt 2
+                            ]
                         -- ss
                         |= oneOf
                             [ succeed identity
@@ -377,11 +382,19 @@ monthYearDayInMs =
     Parser.succeed (\year month day -> ( year, month, day ))
         |= paddedInt 4
         -- YYYY
-        |. symbol "-"
-        |= paddedInt 2
+        |= oneOf
+            [ succeed identity
+                |. symbol "-"
+                |= paddedInt 2
+            , paddedInt 2
+            ]
         -- MM
-        |. symbol "-"
-        |= paddedInt 2
+        |= oneOf
+            [ succeed identity
+                |. symbol "-"
+                |= paddedInt 2
+            , paddedInt 2
+            ]
         -- DD
         |> Parser.andThen yearMonthDay
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -58,6 +58,14 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2018-08-31T23:25:16.0123456789+02:00"
                     |> Expect.err
+        , test "toTime supports no delimeters" <|
+            \_ ->
+                Iso8601.toTime "20180831T232516Z"
+                    |> Expect.equal (Ok (Time.millisToPosix 1535757916000))
+        , test "toTime supports nanoseconds precision when there are no delimeters" <|
+            \_ ->
+                Iso8601.toTime "20180831T232516.019345123+02:00"
+                    |> Expect.equal (Ok (Time.millisToPosix 1535750716019))
         ]
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -78,6 +78,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2012-11-12T00:00:00+01"
                     |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
+        , test "toTime fails on invalid offset" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+0130546"
+                    |> Expect.err
         ]
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -70,6 +70,18 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2080831T232516Z"
                     |> Expect.err
+        , test "toTime supports no delimiter in offset" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+0130"
+                    |> Expect.equal (Ok (Time.millisToPosix 1352673000000))
+        , test "toTime supports offset with only hours" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+01"
+                    |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
+        , test "toTime fails on invalid offset" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+0130546"
+                    |> Expect.err
         ]
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -66,6 +66,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "20180831T232516.019345123+02:00"
                     |> Expect.equal (Ok (Time.millisToPosix 1535750716019))
+        , test "toTime fails with no delimeters and not enough numbers" <|
+            \_ ->
+                Iso8601.toTime "2080831T232516Z"
+                    |> Expect.err
         ]
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -72,16 +72,12 @@ knownValues =
                     |> Expect.err
         , test "toTime supports no delimiter in offset" <|
             \_ ->
-                Iso8601.toTime "2012-11-12T00:00:00+0130"
-                    |> Expect.equal (Ok (Time.millisToPosix 1352673000000))
+                Iso8601.toTime "2012-11-12T00:00:00+0100"
+                    |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
         , test "toTime supports offset with only hours" <|
             \_ ->
                 Iso8601.toTime "2012-11-12T00:00:00+01"
                     |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
-        , test "toTime fails on invalid offset" <|
-            \_ ->
-                Iso8601.toTime "2012-11-12T00:00:00+0130546"
-                    |> Expect.err
         ]
 
 


### PR DESCRIPTION
Reopening PR based on PR #15 which add support for no delimiters (basically same as #16).

This PR adds support for no delimiters in offset which is valid ISO 8601 format.

Format sources:
https://www.cl.cam.ac.uk/~mgk25/iso-time.html (under the heading "Time Zones")
https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
https://www.ietf.org/rfc/rfc3339.txt (See definition of time-numoffset on page 12)

I closed PR #15 and instead added to the existing PR from [gyzerok](/gyzerok)  but they are all closed so adding this again.