### PR TITLE
added capability for yyyy-mm-ddThh:mm format and added a test

### DIFF
--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -317,6 +317,7 @@ iso8601 =
                                 |. symbol ":"
                                 |= paddedInt 2
                             , paddedInt 2
+                            , succeed 0
                             ]
                         -- ss
                         |= oneOf
@@ -366,7 +367,7 @@ utcOffsetInMinutes =
             -- No "Z" is valid
             , succeed 0
                 |. end
-            ]            
+            ]
 
 
 {-| Parse fractions of a second, and convert to milliseconds

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -94,6 +94,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2012-11-12T00:00:00+0130546"
                     |> Expect.err
+        , test "toTime supports yyyy-mm-ddThh:mm format" <|
+            \_ ->
+                Iso8601.toTime "2019-05-30T06:30"
+                    |> Expect.equal (Ok (Time.millisToPosix 1559197800000))
         ]
 
 


### PR DESCRIPTION
I fixed the yyyy-mm-ddThh:mm format by adding a `succeed 0` to the seconds `oneOf` in the parser.

I also added a test. 