### PR TITLE
EISO8601-IN25: Unhelpful TODO output from decoder failure

### DIFF
--- a/src/DeadEnds.elm
+++ b/src/DeadEnds.elm
@@ -1,0 +1,63 @@
+module DeadEnds exposing (..)
+
+import Parser exposing (..)
+
+
+
+{- This implementation is taken from elm/parser PR #16 by @bburdette and provides clearer dead ends output for the end user -}
+
+
+deadEndsToString : List DeadEnd -> String
+deadEndsToString deadEnds =
+    String.concat (List.intersperse "; " (List.map deadEndToString deadEnds))
+
+
+deadEndToString : DeadEnd -> String
+deadEndToString deadend =
+    problemToString deadend.problem ++ " at row " ++ String.fromInt deadend.row ++ ", col " ++ String.fromInt deadend.col
+
+
+problemToString : Problem -> String
+problemToString p =
+    case p of
+        Expecting s ->
+            "expecting '" ++ s ++ "'"
+
+        ExpectingInt ->
+            "expecting int"
+
+        ExpectingHex ->
+            "expecting hex"
+
+        ExpectingOctal ->
+            "expecting octal"
+
+        ExpectingBinary ->
+            "expecting binary"
+
+        ExpectingFloat ->
+            "expecting float"
+
+        ExpectingNumber ->
+            "expecting number"
+
+        ExpectingVariable ->
+            "expecting variable"
+
+        ExpectingSymbol s ->
+            "expecting symbol '" ++ s ++ "'"
+
+        ExpectingKeyword s ->
+            "expecting keyword '" ++ s ++ "'"
+
+        ExpectingEnd ->
+            "expecting end"
+
+        UnexpectedChar ->
+            "unexpected char"
+
+        Problem s ->
+            "problem " ++ s
+
+        BadRepeat ->
+            "bad repeat"

--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -6,9 +6,10 @@ module Iso8601 exposing (fromTime, toTime, decoder, encode)
 
 -}
 
+import DeadEnds exposing (deadEndsToString)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
-import Parser exposing ((|.), (|=), Parser, andThen, end, int, map, oneOf, succeed, symbol)
+import Parser exposing ((|.), (|=), Parser, andThen, end, map, oneOf, succeed, symbol)
 import Time exposing (Month(..), utc)
 
 
@@ -21,7 +22,7 @@ decoder =
             (\str ->
                 case toTime str of
                     Err deadEnds ->
-                        Decode.fail <| Parser.deadEndsToString deadEnds
+                        Decode.fail <| deadEndsToString deadEnds
 
                     Ok time ->
                         Decode.succeed time
@@ -366,7 +367,7 @@ utcOffsetInMinutes =
             -- No "Z" is valid
             , succeed 0
                 |. end
-            ]            
+            ]
 
 
 {-| Parse fractions of a second, and convert to milliseconds

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -1,10 +1,11 @@
 module Example exposing (knownValues, reflexive)
 
-import Expect exposing (Expectation)
-import Fuzz exposing (Fuzzer, float, int, list, string)
+import Expect
+import Fuzz
 import Iso8601
 import Test exposing (..)
 import Time
+import Json.Decode exposing (decodeString, errorToString)
 
 
 knownValues : Test
@@ -94,12 +95,19 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2012-11-12T00:00:00+0130546"
                     |> Expect.err
+        , test "decoder returns clearer error for dead ends" <|
+            \_ ->
+                case decodeString Iso8601.decoder "2010-09-31T14:29:25.01235Z" of
+                    Err error ->
+                        Expect.notEqual (errorToString error) "TODO deadEndsToString"
+                    Ok _ ->
+                        Expect.fail "Should fail on dead ends"
         ]
 
 
 reflexive : Test
 reflexive =
-    fuzz int "(fromTime >> toTime) is a no-op" <|
+    fuzz Fuzz.int "(fromTime >> toTime) is a no-op" <|
         \num ->
             let
                 time =


### PR DESCRIPTION
Fixes #25 by adding the implementation of `deadEndsToString` from [elm/parser PR 16](https://github.com/elm/parser/pull/16) to provide much clearer end user output of errors until such times as the parser module finally gets an update.. 💭 