### PR TITLE
Bugfix/dates with zero as day return no error

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "rtfeldman/elm-iso8601-date-strings",
     "summary": "Convert ISO8601 date strings to and from Posix times",
     "license": "BSD-3-Clause",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "exposed-modules": [
         "Iso8601"
     ],

--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -100,7 +100,7 @@ epochYear =
 
 yearMonthDay : ( Int, Int, Int ) -> Parser Int
 yearMonthDay ( year, month, dayInMonth ) =
-    if dayInMonth < 0 then
+    if dayInMonth < 1 then
         invalidDay dayInMonth
 
     else

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -59,6 +59,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "1970-01-01"
                     |> Expect.equal (Ok (Time.millisToPosix 0))
+        , test "Invalid day gives error" <|
+            \_ ->
+                Iso8601.toTime "2000-01-00"
+                    |> Expect.err
         , test "toTime supports microseconds precision" <|
             \_ ->
                 Iso8601.toTime "2018-08-31T23:25:16.019345+02:00"


### PR DESCRIPTION
Fix for https://github.com/rtfeldman/elm-iso8601-date-strings/issues/29