### PR TITLE
Fix negative timestamps parsing incorrectly

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,6 +15,6 @@
         "elm/time": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.0.0 <= v < 2.0.0"
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
     }
 }

--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -342,7 +342,7 @@ utcOffsetInMinutes =
         utcOffsetMinutesFromParts : Int -> Int -> Int -> Int
         utcOffsetMinutesFromParts multiplier hours minutes =
             -- multiplier is either 1 or -1 (for negative UTC offsets)
-            multiplier * (hours * 60) + minutes
+            multiplier * ((hours * 60) + minutes)
     in
     Parser.succeed identity
         |= oneOf

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -3,9 +3,9 @@ module Example exposing (knownValues, reflexive)
 import Expect
 import Fuzz
 import Iso8601
+import Json.Decode exposing (decodeString, errorToString)
 import Test exposing (..)
 import Time
-import Json.Decode exposing (decodeString, errorToString)
 
 
 knownValues : Test
@@ -99,11 +99,20 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2019-05-30T06:30"
                     |> Expect.equal (Ok (Time.millisToPosix 1559197800000))
+        , test "toTime supports negative timestamps (French Polynesia: Marquesas Islands)" <|
+            \_ ->
+                Iso8601.toTime "2022-11-21T00:00:00-09:30"
+                    |> Expect.equal (Ok (Time.millisToPosix 1669023000000))
+        , test "toTime supports negative timestamps (Canada: Newfoundland, Labrador (southeast))" <|
+            \_ ->
+                Iso8601.toTime "2022-11-21T00:00:00-03:30"
+                    |> Expect.equal (Ok (Time.millisToPosix 1669001400000))
         , test "decoder returns clearer error for dead ends" <|
             \_ ->
                 case decodeString Iso8601.decoder "2010-09-31T14:29:25.01235Z" of
                     Err error ->
                         Expect.notEqual (errorToString error) "TODO deadEndsToString"
+
                     Ok _ ->
                         Expect.fail "Should fail on dead ends"
         ]


### PR DESCRIPTION
Closes #31 

Currently the `utcOffsetMinutesFromParts` helper calculates the offset incorrectly by a slim margin, but enough to be concerning, when provided with negative timestamps such as those in the tests provided as part of this PR.

To validate the changes you can paste the test case ISO-8601 strings into a converter like [Dencode](https://dencode.com/date) to see the stamps are correctly conforming as intended.

This is actually quite a surprising issue so kudos to @pd9333 for catching this one! 🎉 