### PR TITLE
Add tests for the calendar date spectrum

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,6 +15,6 @@
         "elm/time": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.0.0 <= v < 2.0.0"
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
     }
 }

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -3,9 +3,9 @@ module Example exposing (knownValues, reflexive)
 import Expect
 import Fuzz
 import Iso8601
+import Json.Decode exposing (decodeString, errorToString)
 import Test exposing (..)
 import Time
-import Json.Decode exposing (decodeString, errorToString)
 
 
 knownValues : Test
@@ -99,11 +99,28 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2019-05-30T06:30"
                     |> Expect.equal (Ok (Time.millisToPosix 1559197800000))
+        , test "toTime supports yyyymmddThh:mm truncated representation format" <|
+            \_ ->
+                Iso8601.toTime "20190530T06:30"
+                    |> Expect.equal (Ok (Time.millisToPosix 1559197800000))
+        , test "toTime supports yyyymmdd truncated representation format" <|
+            \_ ->
+                Iso8601.toTime "2019-05-30"
+                    |> Expect.equal (Ok (Time.millisToPosix 1559174400000))
+        , test "toTime does not support the deprecated yyyymm truncated representation format" <|
+            \_ ->
+                Iso8601.toTime "201905"
+                    |> Expect.err
+        , test "toTime does not support the deprecated yyyy truncated representation format" <|
+            \_ ->
+                Iso8601.toTime "2019"
+                    |> Expect.err
         , test "decoder returns clearer error for dead ends" <|
             \_ ->
                 case decodeString Iso8601.decoder "2010-09-31T14:29:25.01235Z" of
                     Err error ->
                         Expect.notEqual (errorToString error) "TODO deadEndsToString"
+
                     Ok _ ->
                         Expect.fail "Should fail on dead ends"
         ]


### PR DESCRIPTION
As described in #21, we should ensure that all forms of [calendar date](https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates) are supported. This PR adds test cases for those date string forms.